### PR TITLE
Use ASDF for version management

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -46,3 +46,6 @@ _load_settings "$HOME/.zsh/configs"
 
 # aliases
 [[ -f ~/.aliases ]] && source ~/.aliases
+
+. $HOME/.asdf/asdf.sh
+. $HOME/.asdf/completions/asdf.bash


### PR DESCRIPTION
ASDF manages languages versions for many languages instead of just one.
This commit adds ASDF to path and completions for zsh, so that it's
easier to use.